### PR TITLE
Ro 104/user fiat to crypto service

### DIFF
--- a/docs/corporate/fiat-to-crypto.md
+++ b/docs/corporate/fiat-to-crypto.md
@@ -17,7 +17,7 @@ interface ICorporateFiatToCryptoService {
   getCorporateUnblockBankAccount(
     params: GetCorporateUnblockBankAccountRequest,
   ): Promise<GetCorporateUnblockBankAccountResponse>;
-  simulateFiatToCrypto(params: SimulateFiatToCryptoRequest): Promise<void>;
+  simulate(params: simulateRequest): Promise<void>;
 }
 ```
 
@@ -70,7 +70,7 @@ type UnblockBankAccount = {
 
 **Object** [UnblockBankAccount](#UnblockBankAccount)
 
-#### <span id="SimulateFiatToCryptoRequest"></span>SimulateFiatToCryptoRequest
+#### <span id="simulateRequest"></span>simulateRequest
 
 | Field Name    | Type   |
 | ------------- | ------ |
@@ -226,9 +226,9 @@ import getUnblockSDK from '@getunblock/sdk';
 })();
 ```
 
-#### simulateFiatToCrypto
+#### simulate
 
-<div><pre>simulateFiatToCrypto(params: <a href="#simulatefiattocryptorequest">SimulateFiatToCryptoRequest</a>): Promise&#60;void&#62;</pre></div>
+<div><pre>simulate(params: <a href="#simulaterequest">simulateRequest</a>): Promise&#60;void&#62;</pre></div>
 
 ##### Overview
 
@@ -249,7 +249,7 @@ import getUnblockSDK from '@getunblock/sdk';
   });
 
   // Api call
-  const result = await sdk.corporate.fiatToCrypto.simulateFiatToCrypto({
+  const result = await sdk.corporate.fiatToCrypto.simulate({
     corporateUuid: 'The uuid of the corporate',
     accountUuid: 'The uuid of the account',
     value: 100, // The amount of the account's currency used for simulation
@@ -270,7 +270,7 @@ import getUnblockSDK from '@getunblock/sdk';
   });
 
   // Api call
-  const result = await sdk.corporate.fiatToCrypto.simulateFiatToCrypto({
+  const result = await sdk.corporate.fiatToCrypto.simulate({
     corporateUuid: 'The uuid of the corporate',
     accountUuid: 'The uuid of the account',
     value: 100, // The amount of the account's currency used for simulation

--- a/docs/old_docs/UNBLOCK_BANK_ACCOUNT.md
+++ b/docs/old_docs/UNBLOCK_BANK_ACCOUNT.md
@@ -8,10 +8,14 @@ category: 64aebfcf6c645e002384ccdc
 
 ```typescript
 interface IUnblockBankAccountService {
-  createUnblockUserBankAccount(params: CreateUnblockUserBankAccountRequest): Promise<CreateUnblockUserBankAccountResponse>;
+  createUnblockUserBankAccount(
+    params: CreateUnblockUserBankAccountRequest,
+  ): Promise<CreateUnblockUserBankAccountResponse>;
   getAllUnblockUserBankAccounts(): Promise<GetAllunblockUserBankAccountsResponse>;
   simulateOnRamp(params: SimulateOnRampRequest): Promise<SimulateOnRampResponse>;
-  getUnblockBankAccountById(params: GetUnblockBankAccountByIdRequest): Promise<GetUnblockBankAccountByIdResponse>;
+  getUnblockBankAccountByUuid(
+    params: getUnblockBankAccountByUuidRequest,
+  ): Promise<getUnblockBankAccountByUuidResponse>;
 }
 ```
 
@@ -31,57 +35,57 @@ type CreateUnblockUserBankAccountResponse = UserBankAccount;
 type GetAllunblockUserBankAccountsResponse = UserBankAccount[];
 ```
 
-<span id="GetUnblockBankAccountByIdResponse"></span>
+<span id="getUnblockBankAccountByUuidResponse"></span>
 
 ```typescript
-type GetUnblockBankAccountByIdResponse = UserBankAccount & UserBankAccountDetails;
+type getUnblockBankAccountByUuidResponse = UserBankAccount & UserBankAccountDetails;
 ```
 
 #### <span id="CreateUnblockUserBankAccountRequest"></span>CreateUnblockUserBankAccountRequest
 
-| Field Name | Type |
-| ---------- | ---- |
-| currency | [Currency](COMMON_TYPES.md#Currency) |
+| Field Name | Type                                 |
+| ---------- | ------------------------------------ |
+| currency   | [Currency](COMMON_TYPES.md#Currency) |
 
 #### <span id="SimulateOnRampRequest"></span>SimulateOnRampRequest
 
-| Field Name | Type |
-| ---------- | ---- |
-| currency | [Currency](COMMON_TYPES.md#Currency) |
-| value | number |
+| Field Name | Type                                 |
+| ---------- | ------------------------------------ |
+| currency   | [Currency](COMMON_TYPES.md#Currency) |
+| value      | number                               |
 
-#### <span id="GetUnblockBankAccountByIdRequest"></span>GetUnblockBankAccountByIdRequest
+#### <span id="getUnblockBankAccountByUuidRequest"></span>getUnblockBankAccountByUuidRequest
 
-| Field Name | Type |
-| ---------- | ---- |
+| Field Name  | Type   |
+| ----------- | ------ |
 | accountUuid | string |
 
 #### <span id="UserBankAccount"></span>UserBankAccount
 
-| Field Name | Type |
-| ---------- | ---- |
-| currency | [Currency](COMMON_TYPES.md#Currency) |
-| createdAt | string |
-| updatedAt | string |
-| uuid | string |
+| Field Name | Type                                 |
+| ---------- | ------------------------------------ |
+| currency   | [Currency](COMMON_TYPES.md#Currency) |
+| createdAt  | string                               |
+| updatedAt  | string                               |
+| uuid       | string                               |
 
 #### <span id="UserBankAccountDetails"></span>UserBankAccountDetails
 
-| Field Name | Type |
-| ---------- | ---- |
-| bic | string |
-| accountNumber | string |
-| iban | string |
-| holderName | string |
-| currentBalance | number |
+| Field Name       | Type   |
+| ---------------- | ------ |
+| bic              | string |
+| accountNumber    | string |
+| iban             | string |
+| holderName       | string |
+| currentBalance   | number |
 | availableBalance | number |
-| sortCode | string |
+| sortCode         | string |
 
 #### <span id="SimulateOnRampResponse"></span>SimulateOnRampResponse
 
-| Field Name | Type |
-| ---------- | ---- |
-| message | string |
+| Field Name | Type   |
+| ---------- | ------ |
+| message    | string |
 
 ### Service Methods
 
@@ -98,25 +102,24 @@ This method allows to creates a new bank account for a user in Unblock system fo
 ###### Typescript
 
 ```typescript
-import getunblockSDK, { AuthenticationMethod, Currency } from "@getunblock/sdk";
+import getunblockSDK, { AuthenticationMethod, Currency } from '@getunblock/sdk';
 
 (async () => {
   // setup SDK
   const sdk = getunblockSDK({
-    apiKey:
-      "API-Key [Some merchant Key]", // Key generated at the moment the merchant was created in getunblock system
+    apiKey: 'API-Key [Some merchant Key]', // Key generated at the moment the merchant was created in getunblock system
     prod: false, // If true Production environment will be used otherwise Sandbox will be used instead
   });
-  
-  await sdk.auth.authenticateWithSiwe({    
-    message: "[Generated SIWE message]*",
-    signature: "[Generated SIWE signature]*",
+
+  await sdk.auth.authenticateWithSiwe({
+    message: '[Generated SIWE message]*',
+    signature: '[Generated SIWE signature]*',
   });
   // * more info at https://docs.getunblock.com/docs/unblocker
-  
+
   // SDK API call example
   const result = await sdk.unblockBankAccount.createUnblockUserBankAccount({
-    currency: Currency.GBP
+    currency: Currency.GBP,
   });
 })();
 ```
@@ -124,26 +127,25 @@ import getunblockSDK, { AuthenticationMethod, Currency } from "@getunblock/sdk";
 ###### Javascript
 
 ```javascript
-const getunblockSDK = require("@getunblock/sdk").default;
-const { AuthenticationMethod, Currency } = require("@getunblock/sdk"); 
+const getunblockSDK = require('@getunblock/sdk').default;
+const { AuthenticationMethod, Currency } = require('@getunblock/sdk');
 
 (async () => {
   // setup SDK
   const sdk = getunblockSDK({
-    apiKey:
-      "API-Key [Some merchant Key]", // Key generated at the moment the merchant was created in getunblock system
+    apiKey: 'API-Key [Some merchant Key]', // Key generated at the moment the merchant was created in getunblock system
     prod: false, // If true Production environment will be used otherwise Sandbox will be used instead
   });
-  
-  await sdk.auth.authenticateWithSiwe({    
-    message: "[Generated SIWE message]*",
-    signature: "[Generated SIWE signature]*",
+
+  await sdk.auth.authenticateWithSiwe({
+    message: '[Generated SIWE message]*',
+    signature: '[Generated SIWE signature]*',
   });
   // * more info at https://docs.getunblock.com/docs/unblocker
-  
+
   // SDK API call example
   const result = await sdk.unblockBankAccount.createUnblockUserBankAccount({
-    currency: Currency.GBP
+    currency: Currency.GBP,
   });
 })();
 ```
@@ -161,22 +163,21 @@ This method returns a list of all user account by unblock
 ###### Typescript
 
 ```typescript
-import getunblockSDK, { AuthenticationMethod } from "@getunblock/sdk";
+import getunblockSDK, { AuthenticationMethod } from '@getunblock/sdk';
 
 (async () => {
   // setup SDK
   const sdk = getunblockSDK({
-    apiKey:
-      "API-Key [Some merchant Key]", // Key generated at the moment the merchant was created in getunblock system
+    apiKey: 'API-Key [Some merchant Key]', // Key generated at the moment the merchant was created in getunblock system
     prod: false, // If true Production environment will be used otherwise Sandbox will be used instead
   });
-  
-  await sdk.auth.authenticateWithSiwe({    
-    message: "[Generated SIWE message]*",
-    signature: "[Generated SIWE signature]*",
+
+  await sdk.auth.authenticateWithSiwe({
+    message: '[Generated SIWE message]*',
+    signature: '[Generated SIWE signature]*',
   });
   // * more info at https://docs.getunblock.com/docs/unblocker
-  
+
   // SDK API call example
   const result = await sdk.unblockBankAccount.getAllUnblockUserBankAccounts();
 })();
@@ -185,23 +186,22 @@ import getunblockSDK, { AuthenticationMethod } from "@getunblock/sdk";
 ###### Javascript
 
 ```javascript
-const getunblockSDK = require("@getunblock/sdk").default;
-const { AuthenticationMethod } = require("@getunblock/sdk"); 
+const getunblockSDK = require('@getunblock/sdk').default;
+const { AuthenticationMethod } = require('@getunblock/sdk');
 
 (async () => {
   // setup SDK
   const sdk = getunblockSDK({
-    apiKey:
-      "API-Key [Some merchant Key]", // Key generated at the moment the merchant was created in getunblock system
+    apiKey: 'API-Key [Some merchant Key]', // Key generated at the moment the merchant was created in getunblock system
     prod: false, // If true Production environment will be used otherwise Sandbox will be used instead
   });
-  
-  await sdk.auth.authenticateWithSiwe({    
-    message: "[Generated SIWE message]*",
-    signature: "[Generated SIWE signature]*",
+
+  await sdk.auth.authenticateWithSiwe({
+    message: '[Generated SIWE message]*',
+    signature: '[Generated SIWE signature]*',
   });
   // * more info at https://docs.getunblock.com/docs/unblocker
-  
+
   // SDK API call example
   const result = await sdk.unblockBankAccount.getAllRemoteBankAccounts();
 })();
@@ -220,26 +220,25 @@ This method simulates an on-ramp operation - Sandbox environment only
 ###### Typescript
 
 ```typescript
-import getunblockSDK, { AuthenticationMethod, Currency } from "@getunblock/sdk";
+import getunblockSDK, { AuthenticationMethod, Currency } from '@getunblock/sdk';
 
 (async () => {
   // setup SDK
   const sdk = getunblockSDK({
-    apiKey:
-      "API-Key [Some merchant Key]", // Key generated at the moment the merchant was created in getunblock system
+    apiKey: 'API-Key [Some merchant Key]', // Key generated at the moment the merchant was created in getunblock system
     prod: false, // If true Production environment will be used otherwise Sandbox will be used instead
   });
-  
-  await sdk.auth.authenticateWithSiwe({    
-    message: "[Generated SIWE message]*",
-    signature: "[Generated SIWE signature]*",
+
+  await sdk.auth.authenticateWithSiwe({
+    message: '[Generated SIWE message]*',
+    signature: '[Generated SIWE signature]*',
   });
   // * more info at https://docs.getunblock.com/docs/unblocker
-  
+
   // SDK API call example
   const result = await sdk.unblockBankAccount.simulateOnRamp({
     currency: Currency.GBP,
-    value: 1
+    value: 1,
   });
 })();
 ```
@@ -247,34 +246,33 @@ import getunblockSDK, { AuthenticationMethod, Currency } from "@getunblock/sdk";
 ###### Javascript
 
 ```javascript
-const getunblockSDK = require("@getunblock/sdk").default;
-const { AuthenticationMethod, Currency } = require("@getunblock/sdk"); 
+const getunblockSDK = require('@getunblock/sdk').default;
+const { AuthenticationMethod, Currency } = require('@getunblock/sdk');
 
 (async () => {
   // setup SDK
   const sdk = getunblockSDK({
-    apiKey:
-      "API-Key [Some merchant Key]", // Key generated at the moment the merchant was created in getunblock system
+    apiKey: 'API-Key [Some merchant Key]', // Key generated at the moment the merchant was created in getunblock system
     prod: false, // If true Production environment will be used otherwise Sandbox will be used instead
   });
-  
-  await sdk.auth.authenticateWithSiwe({    
-    message: "[Generated SIWE message]*",
-    signature: "[Generated SIWE signature]*",
+
+  await sdk.auth.authenticateWithSiwe({
+    message: '[Generated SIWE message]*',
+    signature: '[Generated SIWE signature]*',
   });
   // * more info at https://docs.getunblock.com/docs/unblocker
-  
+
   // SDK API call example
   const result = await sdk.unblockBankAccount.simulateOnRamp({
     currency: Currency.GBP,
-    value: 1
+    value: 1,
   });
 })();
 ```
 
-#### getUnblockBankAccountById
+#### getUnblockBankAccountByUuid
 
-<div><pre>getUnblockBankAccountById(params: <a href="#GetUnblockBankAccountByIdRequest">GetUnblockBankAccountByIdRequest</a>): Promise&#60;<a href="#GetUnblockBankAccountByIdResponse">GetUnblockBankAccountByIdResponse</a>&#62;</pre></div>
+<div><pre>getUnblockBankAccountByUuid(params: <a href="#getUnblockBankAccountByUuidRequest">getUnblockBankAccountByUuidRequest</a>): Promise&#60;<a href="#getUnblockBankAccountByUuidResponse">getUnblockBankAccountByUuidResponse</a>&#62;</pre></div>
 
 ##### Overview
 
@@ -285,25 +283,24 @@ This method returns details of user bank account by unblock based on id. For GBP
 ###### Typescript
 
 ```typescript
-import getunblockSDK, { AuthenticationMethod } from "@getunblock/sdk";
+import getunblockSDK, { AuthenticationMethod } from '@getunblock/sdk';
 
 (async () => {
   // setup SDK
   const sdk = getunblockSDK({
-    apiKey:
-      "API-Key [Some merchant Key]", // Key generated at the moment the merchant was created in getunblock system
+    apiKey: 'API-Key [Some merchant Key]', // Key generated at the moment the merchant was created in getunblock system
     prod: false, // If true Production environment will be used otherwise Sandbox will be used instead
   });
-  
-  await sdk.auth.authenticateWithSiwe({    
-    message: "[Generated SIWE message]*",
-    signature: "[Generated SIWE signature]*",
+
+  await sdk.auth.authenticateWithSiwe({
+    message: '[Generated SIWE message]*',
+    signature: '[Generated SIWE signature]*',
   });
   // * more info at https://docs.getunblock.com/docs/unblocker
-  
+
   // SDK API call example
-  const result = await sdk.unblockBankAccount.getUnblockBankAccountById({
-    accountUuid: "b89b8075-e845-48a6-9b70-123c12e0aed0",
+  const result = await sdk.unblockBankAccount.getUnblockBankAccountByUuid({
+    accountUuid: 'b89b8075-e845-48a6-9b70-123c12e0aed0',
   });
 })();
 ```
@@ -311,26 +308,25 @@ import getunblockSDK, { AuthenticationMethod } from "@getunblock/sdk";
 ###### Javascript
 
 ```javascript
-const getunblockSDK = require("@getunblock/sdk").default;
-const { AuthenticationMethod } = require("@getunblock/sdk"); 
+const getunblockSDK = require('@getunblock/sdk').default;
+const { AuthenticationMethod } = require('@getunblock/sdk');
 
 (async () => {
   // setup SDK
   const sdk = getunblockSDK({
-    apiKey:
-      "API-Key [Some merchant Key]", // Key generated at the moment the merchant was created in getunblock system
+    apiKey: 'API-Key [Some merchant Key]', // Key generated at the moment the merchant was created in getunblock system
     prod: false, // If true Production environment will be used otherwise Sandbox will be used instead
   });
-  
-  await sdk.auth.authenticateWithSiwe({    
-    message: "[Generated SIWE message]*",
-    signature: "[Generated SIWE signature]*",
+
+  await sdk.auth.authenticateWithSiwe({
+    message: '[Generated SIWE message]*',
+    signature: '[Generated SIWE signature]*',
   });
   // * more info at https://docs.getunblock.com/docs/unblocker
-  
+
   // SDK API call example
-  const result = await sdk.unblockBankAccount.getUnblockBankAccountById({
-    accountUuid: "b89b8075-e845-48a6-9b70-123c12e0aed0",
+  const result = await sdk.unblockBankAccount.getUnblockBankAccountByUuid({
+    accountUuid: 'b89b8075-e845-48a6-9b70-123c12e0aed0',
   });
 })();
 ```
@@ -338,16 +334,17 @@ const { AuthenticationMethod } = require("@getunblock/sdk");
 <div class="CodeMirror-gutter-filler">
 <h3>Other Services Available</h3>
 
-* [auth](AUTH.md)
-* [company](COMPANY.md)
-* [exchangeRates](EXCHANGE_RATES.md)
-* [kyc](KYC.md)
-* [offramp](OFFRAMP.md)
-* [process](PROCESS.md)
-* [remoteBankAccount](REMOTE_BANK_ACCOUNT.md)
-* [tokenPreferences](TOKEN_PREFERENCES.md)
-* [transactionFee](TRANSACTION_FEE.md)
-* [user](USER.md)
+- [auth](AUTH.md)
+- [company](COMPANY.md)
+- [exchangeRates](EXCHANGE_RATES.md)
+- [kyc](KYC.md)
+- [offramp](OFFRAMP.md)
+- [process](PROCESS.md)
+- [remoteBankAccount](REMOTE_BANK_ACCOUNT.md)
+- [tokenPreferences](TOKEN_PREFERENCES.md)
+- [transactionFee](TRANSACTION_FEE.md)
+- [user](USER.md)
 
 [Back to README](../README.md)
+
 </div>

--- a/docs/old_docs/UNBLOCK_BANK_ACCOUNT.md
+++ b/docs/old_docs/UNBLOCK_BANK_ACCOUNT.md
@@ -12,7 +12,7 @@ interface IUnblockBankAccountService {
     params: CreateUnblockUserBankAccountRequest,
   ): Promise<CreateUnblockUserBankAccountResponse>;
   getAllUnblockUserBankAccounts(): Promise<GetAllunblockUserBankAccountsResponse>;
-  simulateOnRamp(params: SimulateOnRampRequest): Promise<SimulateOnRampResponse>;
+  simulate(params: simulateRequest): Promise<simulateResponse>;
   getUnblockBankAccountByUuid(
     params: getUnblockBankAccountByUuidRequest,
   ): Promise<getUnblockBankAccountByUuidResponse>;
@@ -47,7 +47,7 @@ type getUnblockBankAccountByUuidResponse = UserBankAccount & UserBankAccountDeta
 | ---------- | ------------------------------------ |
 | currency   | [Currency](COMMON_TYPES.md#Currency) |
 
-#### <span id="SimulateOnRampRequest"></span>SimulateOnRampRequest
+#### <span id="simulateRequest"></span>simulateRequest
 
 | Field Name | Type                                 |
 | ---------- | ------------------------------------ |
@@ -81,7 +81,7 @@ type getUnblockBankAccountByUuidResponse = UserBankAccount & UserBankAccountDeta
 | availableBalance | number |
 | sortCode         | string |
 
-#### <span id="SimulateOnRampResponse"></span>SimulateOnRampResponse
+#### <span id="simulateResponse"></span>simulateResponse
 
 | Field Name | Type   |
 | ---------- | ------ |
@@ -207,9 +207,9 @@ const { AuthenticationMethod } = require('@getunblock/sdk');
 })();
 ```
 
-#### simulateOnRamp
+#### simulate
 
-<div><pre>simulateOnRamp(params: <a href="#SimulateOnRampRequest">SimulateOnRampRequest</a>): Promise&#60;<a href="#SimulateOnRampResponse">SimulateOnRampResponse</a>&#62;</pre></div>
+<div><pre>simulate(params: <a href="#simulateRequest">simulateRequest</a>): Promise&#60;<a href="#simulateResponse">simulateResponse</a>&#62;</pre></div>
 
 ##### Overview
 
@@ -236,7 +236,7 @@ import getunblockSDK, { AuthenticationMethod, Currency } from '@getunblock/sdk';
   // * more info at https://docs.getunblock.com/docs/unblocker
 
   // SDK API call example
-  const result = await sdk.unblockBankAccount.simulateOnRamp({
+  const result = await sdk.unblockBankAccount.simulate({
     currency: Currency.GBP,
     value: 1,
   });
@@ -263,7 +263,7 @@ const { AuthenticationMethod, Currency } = require('@getunblock/sdk');
   // * more info at https://docs.getunblock.com/docs/unblocker
 
   // SDK API call example
-  const result = await sdk.unblockBankAccount.simulateOnRamp({
+  const result = await sdk.unblockBankAccount.simulate({
     currency: Currency.GBP,
     value: 1,
   });

--- a/docs/user/crypto-to-fiat.md
+++ b/docs/user/crypto-to-fiat.md
@@ -356,3 +356,10 @@ import getUnblockSDK from '@getunblock/sdk';
   });
 })();
 ```
+
+<div class="CodeMirror-gutter-filler">
+
+[Back to user services index](./index.md)
+[Back to root index](../index.md)
+
+</div>

--- a/docs/user/fiat-to-crypto.md
+++ b/docs/user/fiat-to-crypto.md
@@ -1,0 +1,272 @@
+---
+title: User Fiat to Crypto Service
+excerpt: Reference page for the user fiat to crypto service interface
+category: 64aebfcf6c645e002384ccdc
+---
+
+## Interface
+
+```typescript
+interface IUserFiatToCryptoService {
+  createUnblockUserBankAccount(
+    params: CreateUnblockUserBankAccountRequest,
+  ): Promise<CreateUnblockUserBankAccountResponse>;
+
+  getAllUnblockUserBankAccounts(): Promise<GetAllunblockUserBankAccountsResponse>;
+
+  simulate(params: simulateRequest): Promise<void>;
+
+  getUnblockBankAccountByUuid(
+    params: GetUnblockBankAccountByUuidRequest,
+  ): Promise<GetUnblockBankAccountByUuidResponse>;
+}
+```
+
+### Structures used
+
+#### Union types, Literal types, Enums and Other Interfaces
+
+<span id="UnblockBankAccount"></span>UnblockBankAccount
+
+```typescript
+export type UnblockBankAccount = {
+  uuid: string;
+  currency: Currency;
+  iban: string;
+  bic: string;
+  accountNumber: string;
+  sortCode: string;
+};
+```
+
+#### <span id="CreateUnblockUserBankAccountRequest"></span>CreateUnblockUserBankAccountRequest
+
+| Field Name | Type                                    |
+| ---------- | --------------------------------------- |
+| currency   | [Currency](../common-types.md#currency) |
+
+#### <span id="CreateUnblockUserBankAccountResponse"></span>CreateUnblockUserBankAccountResponse
+
+**Object** [UnblockBankAccount](#UnblockBankAccount)
+
+#### <span id="GetAllunblockUserBankAccountsResponse"></span>GetAllunblockUserBankAccountsResponse
+
+**Array of Objects** [UnblockBankAccount](#UnblockBankAccount)
+
+#### <span id="GetUnblockBankAccountByUuidRequest"></span>GetUnblockBankAccountByUuidRequest
+
+| Field Name  | Type   |
+| ----------- | ------ |
+| accountUuid | string |
+
+#### <span id="GetUnblockBankAccountByUuidResponse"></span>GetUnblockBankAccountByUuidResponse
+
+**Object** [UnblockBankAccount](#UnblockBankAccount)
+
+#### <span id="simulateRequest"></span>simulateRequest
+
+| Field Name  | Type   |
+| ----------- | ------ |
+| accountUuid | string |
+| value       | number |
+
+### Service methods
+
+#### createUnblockUserBankAccount
+
+<div><pre>createUnblockUserBankAccount(params: <a href="#createunblockuserbankaccountrequest">CreateUnblockUserBankAccountRequest</a>): Promise&#60;<a href="#createunblockuserbankaccountresponse">CreateUnblockUserBankAccountResponse</a>&#62;</pre></div>
+
+##### Overview
+
+This method allows an user to create a new unblock bank account which the user can use to go from fiat to crypto
+
+##### Usage
+
+###### Typescript
+
+```typescript
+import getUnblockSDK from '@getunblock/sdk';
+
+(async () => {
+  //Setup SDK
+  const sdk = getUnblockSDK({
+    apiKey: 'API-Key [Your api key here]', // This key will be generated and provided by Unblock
+    prod: false, // If true, the sdk will contact the production environment, otherwise Sandbox
+  });
+
+  // Api call
+  const result = await sdk.user.fiatToCrypto.createUnblockUserBankAccount({
+    currency: Currency.EURO,
+  });
+})();
+```
+
+###### Javascript
+
+```javascript
+import getUnblockSDK from '@getunblock/sdk';
+
+(async () => {
+  //Setup SDK
+  const sdk = getUnblockSDK({
+    apiKey: 'API-Key [Your api key here]', // This key will be generated and provided by Unblock
+    prod: false, // If true, the sdk will contact the production environment, otherwise Sandbox
+  });
+
+  // Api call
+  const result = await sdk.user.fiatToCrypto.createUnblockUserBankAccount({
+    currency: Currency.EURO,
+  });
+})();
+```
+
+#### getAllUnblockUserBankAccounts
+
+<div><pre>getAllUnblockUserBankAccounts(params: void): Promise&#60;<a href="#getallunblockuserbankaccountsresponse">GetAllUnblockUserBankAccountsResponse</a>&#62;</pre></div>
+
+##### Overview
+
+This method allows an user to obtain all the unblock bank accounts registered in its name
+
+##### Usage
+
+###### Typescript
+
+```typescript
+import getUnblockSDK from '@getunblock/sdk';
+
+(async () => {
+  //Setup SDK
+  const sdk = getUnblockSDK({
+    apiKey: 'API-Key [Your api key here]', // This key will be generated and provided by Unblock
+    prod: false, // If true, the sdk will contact the production environment, otherwise Sandbox
+  });
+
+  // Api call
+  const result = await sdk.user.fiatToCrypto.getAllUnblockUserBankAccounts();
+})();
+```
+
+###### Javascript
+
+```javascript
+import getUnblockSDK from '@getunblock/sdk';
+
+(async () => {
+  //Setup SDK
+  const sdk = getUnblockSDK({
+    apiKey: 'API-Key [Your api key here]', // This key will be generated and provided by Unblock
+    prod: false, // If true, the sdk will contact the production environment, otherwise Sandbox
+  });
+
+  // Api call
+  const result = await sdk.user.fiatToCrypto.getAllUnblockUserBankAccounts();
+})();
+```
+
+#### getUnblockBankAccountByUuid
+
+<div><pre>getUnblockBankAccountByUuid(params: <a href="#getunblockbankaccountbyuuidrequest">GetUnblockBankAccountByUuidRequest</a>): Promise&#60;<a href="#getunblockbankaccountbyuuidresponse">GetUnblockBankAccountByUuidResponse</a>&#62;</pre></div>
+
+##### Overview
+
+This method allows an user to consult the details of a particular unblock bank account registered to its name, by providing the account's uuid
+
+##### Usage
+
+###### Typescript
+
+```typescript
+import getUnblockSDK from '@getunblock/sdk';
+
+(async () => {
+  //Setup SDK
+  const sdk = getUnblockSDK({
+    apiKey: 'API-Key [Your api key here]', // This key will be generated and provided by Unblock
+    prod: false, // If true, the sdk will contact the production environment, otherwise Sandbox
+  });
+
+  // Api call
+  const result = await sdk.user.fiatToCrypto.getUnblockBankAccountByUuid({
+    accountUuid: 'The account uuid here',
+  });
+})();
+```
+
+###### Javascript
+
+```javascript
+import getUnblockSDK from '@getunblock/sdk';
+
+(async () => {
+  //Setup SDK
+  const sdk = getUnblockSDK({
+    apiKey: 'API-Key [Your api key here]', // This key will be generated and provided by Unblock
+    prod: false, // If true, the sdk will contact the production environment, otherwise Sandbox
+  });
+
+  // Api call
+  const result = await sdk.user.fiatToCrypto.getUnblockBankAccountByUuid({
+    accountUuid: 'The account uuid here',
+  });
+})();
+```
+
+#### simulate
+
+<div><pre>simulate(params: <a href="#simulaterequest">simulateRequest</a>): Promise&#60;void&#62;</pre></div>
+
+##### Overview
+
+This method allows an user to simulate a fiat to crypto transaction.
+
+**NOTE:** This method is only available in the sandbox. An error will be thrown if an attempt to simulate is made when using the production environment
+
+##### Usage
+
+###### Typescript
+
+```typescript
+import getUnblockSDK from '@getunblock/sdk';
+
+(async () => {
+  //Setup SDK
+  const sdk = getUnblockSDK({
+    apiKey: 'API-Key [Your api key here]', // This key will be generated and provided by Unblock
+    prod: false, // If true, the sdk will contact the production environment, otherwise Sandbox
+  });
+
+  // Api call
+  const result = await sdk.user.fiatToCrypto.simulate({
+    accountUuid: 'The account uuid here',
+    value: 100,
+  });
+})();
+```
+
+###### Javascript
+
+```javascript
+import getUnblockSDK from '@getunblock/sdk';
+
+(async () => {
+  //Setup SDK
+  const sdk = getUnblockSDK({
+    apiKey: 'API-Key [Your api key here]', // This key will be generated and provided by Unblock
+    prod: false, // If true, the sdk will contact the production environment, otherwise Sandbox
+  });
+
+  // Api call
+  const result = await sdk.user.fiatToCrypto.simulate({
+    accountUuid: 'The account uuid here',
+    value: 100,
+  });
+})();
+```
+
+<div class="CodeMirror-gutter-filler">
+
+[Back to user services index](./index.md)
+[Back to root index](../index.md)
+
+</div>

--- a/src/corporate/fiat-to-crypto/CorporateFiatToCryptoService.ts
+++ b/src/corporate/fiat-to-crypto/CorporateFiatToCryptoService.ts
@@ -9,8 +9,8 @@ import {
   GetCorporateUnblockBankAccountResponse,
   GetCorporateUnblockBankAccountsRequest,
   GetCorporateUnblockBankAccountsResponse,
-  SimulateFiatToCryptoRequest,
   UnblockBankAccount,
+  simulateRequest,
 } from './definitions';
 
 export interface ICorporateFiatToCryptoService {
@@ -23,7 +23,7 @@ export interface ICorporateFiatToCryptoService {
   getCorporateUnblockBankAccount(
     params: GetCorporateUnblockBankAccountRequest,
   ): Promise<GetCorporateUnblockBankAccountResponse>;
-  simulateFiatToCrypto(params: SimulateFiatToCryptoRequest): Promise<void>;
+  simulate(params: simulateRequest): Promise<void>;
 }
 
 export class CorporateFiatToCryptoService
@@ -124,7 +124,7 @@ export class CorporateFiatToCryptoService
     }
   }
 
-  async simulateFiatToCrypto(params: SimulateFiatToCryptoRequest): Promise<void> {
+  async simulate(params: simulateRequest): Promise<void> {
     const { apiKey, userSessionData } = this.props;
 
     try {

--- a/src/corporate/fiat-to-crypto/definitions.ts
+++ b/src/corporate/fiat-to-crypto/definitions.ts
@@ -28,7 +28,7 @@ export type GetCorporateUnblockBankAccountRequest = {
 
 export type GetCorporateUnblockBankAccountResponse = UnblockBankAccount;
 
-export type SimulateFiatToCryptoRequest = {
+export type simulateRequest = {
   corporateUuid: string;
   accountUuid: string;
   value: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,8 @@ export {
   GetAllunblockUserBankAccountsResponse,
   GetUnblockBankAccountByUuidRequest,
   GetUnblockBankAccountByUuidResponse,
-  SimulateOnRampRequest,
   UnblockBankAccount,
+  simulateRequest,
 } from './user/fiat-to-crypto/definitions';
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,13 +54,10 @@ export {
   CreateUnblockUserBankAccountRequest,
   CreateUnblockUserBankAccountResponse,
   GetAllunblockUserBankAccountsResponse,
-  GetUnblockBankAccountByIdRequest,
-  GetUnblockBankAccountByIdResponse,
+  GetUnblockBankAccountByUuidRequest,
+  GetUnblockBankAccountByUuidResponse,
   SimulateOnRampRequest,
-  SimulateOnRampResponse,
-  UserBankAccount,
-  UserBankAccountDetails,
-  UserBankAccountFull,
+  UnblockBankAccount,
 } from './user/fiat-to-crypto/definitions';
 
 export {

--- a/src/user/fiat-to-crypto/UserFiatToCryptoService.ts
+++ b/src/user/fiat-to-crypto/UserFiatToCryptoService.ts
@@ -1,15 +1,15 @@
 import { AxiosResponse } from 'axios';
 import { BaseService } from '../../BaseService';
 import { ErrorHandler } from '../../ErrorHandler';
-import { UserSessionDataNotSetError } from '../../errors';
+import { UnsupportedEnvironmentError, UserSessionDataNotSetError } from '../../errors';
 import {
   CreateUnblockUserBankAccountRequest,
   CreateUnblockUserBankAccountResponse,
   GetAllunblockUserBankAccountsResponse,
   GetUnblockBankAccountByUuidRequest,
   GetUnblockBankAccountByUuidResponse,
-  SimulateOnRampRequest,
   UnblockBankAccount,
+  simulateRequest,
 } from './definitions';
 
 export interface IUserFiatToCryptoService {
@@ -19,7 +19,7 @@ export interface IUserFiatToCryptoService {
 
   getAllUnblockUserBankAccounts(): Promise<GetAllunblockUserBankAccountsResponse>;
 
-  simulateOnRamp(params: SimulateOnRampRequest): Promise<void>;
+  simulate(params: simulateRequest): Promise<void>;
 
   getUnblockBankAccountByUuid(
     params: GetUnblockBankAccountByUuidRequest,
@@ -84,11 +84,15 @@ export class UserFiatToCryptoService extends BaseService implements IUserFiatToC
     }
   }
 
-  async simulateOnRamp(params: SimulateOnRampRequest): Promise<void> {
+  async simulate(params: simulateRequest): Promise<void> {
     const { apiKey } = this.props;
     try {
       if (!this.props.userSessionData?.unblockSessionId) {
         throw new UserSessionDataNotSetError();
+      }
+
+      if (this.props.prod) {
+        throw new UnsupportedEnvironmentError('production');
       }
 
       const path = `/user/bank-account/unblock/${params.accountUuid}/simulate`;

--- a/src/user/fiat-to-crypto/UserFiatToCryptoService.ts
+++ b/src/user/fiat-to-crypto/UserFiatToCryptoService.ts
@@ -6,12 +6,10 @@ import {
   CreateUnblockUserBankAccountRequest,
   CreateUnblockUserBankAccountResponse,
   GetAllunblockUserBankAccountsResponse,
-  GetUnblockBankAccountByIdRequest,
-  GetUnblockBankAccountByIdResponse,
+  GetUnblockBankAccountByUuidRequest,
+  GetUnblockBankAccountByUuidResponse,
   SimulateOnRampRequest,
-  SimulateOnRampResponse,
-  UnblockUserBankAccount,
-  UnblockUserBankAccountFull,
+  UnblockBankAccount,
 } from './definitions';
 
 export interface IUserFiatToCryptoService {
@@ -21,11 +19,11 @@ export interface IUserFiatToCryptoService {
 
   getAllUnblockUserBankAccounts(): Promise<GetAllunblockUserBankAccountsResponse>;
 
-  simulateOnRamp(params: SimulateOnRampRequest): Promise<SimulateOnRampResponse>;
+  simulateOnRamp(params: SimulateOnRampRequest): Promise<void>;
 
-  getUnblockBankAccountById(
-    params: GetUnblockBankAccountByIdRequest,
-  ): Promise<GetUnblockBankAccountByIdResponse>;
+  getUnblockBankAccountByUuid(
+    params: GetUnblockBankAccountByUuidRequest,
+  ): Promise<GetUnblockBankAccountByUuidResponse>;
 }
 
 export class UserFiatToCryptoService extends BaseService implements IUserFiatToCryptoService {
@@ -34,31 +32,26 @@ export class UserFiatToCryptoService extends BaseService implements IUserFiatToC
   ): Promise<CreateUnblockUserBankAccountResponse> {
     const { apiKey } = this.props;
     try {
-      if (!this.props.userSessionData?.userUuid || !this.props.userSessionData.unblockSessionId) {
+      if (!this.props.userSessionData?.unblockSessionId) {
         throw new UserSessionDataNotSetError();
       }
 
-      const path = `/user/${this.props.userSessionData.userUuid}/bank-account/unblock`;
+      const path = `/user/bank-account/unblock`;
       const body = { currency: params.currency };
       const config = {
         headers: {
-          'content-type': 'application/json',
+          'Content-type': 'application/json',
           accept: 'application/json',
           Authorization: apiKey,
           'unblock-session-id': this.props.userSessionData.unblockSessionId,
         },
       };
-      const response: AxiosResponse<UnblockUserBankAccount> = await this.axiosClient.post(
+      const response: AxiosResponse<{ [key: string]: any }> = await this.axiosClient.post(
         path,
         body,
         config,
       );
-      return {
-        currency: response.data.currency,
-        createdAt: response.data.created_at,
-        updatedAt: response.data.updated_at,
-        uuid: response.data.uuid,
-      };
+      return this.mapUnblockBankAccountToCamelCase(response.data);
     } catch (error) {
       ErrorHandler.handle(error);
     }
@@ -67,11 +60,11 @@ export class UserFiatToCryptoService extends BaseService implements IUserFiatToC
   async getAllUnblockUserBankAccounts(): Promise<GetAllunblockUserBankAccountsResponse> {
     const { apiKey } = this.props;
     try {
-      if (!this.props.userSessionData?.userUuid || !this.props.userSessionData.unblockSessionId) {
+      if (!this.props.userSessionData?.unblockSessionId) {
         throw new UserSessionDataNotSetError();
       }
 
-      const path = `/user/${this.props.userSessionData.userUuid}/bank-account/unblock`;
+      const path = `/user/bank-account/unblock`;
       const config = {
         headers: {
           accept: 'application/json',
@@ -79,62 +72,50 @@ export class UserFiatToCryptoService extends BaseService implements IUserFiatToC
           'unblock-session-id': this.props.userSessionData.unblockSessionId,
         },
       };
-      const response: AxiosResponse<UnblockUserBankAccount[]> = await this.axiosClient.get(
+      const response: AxiosResponse<{ [key: string]: any }[]> = await this.axiosClient.get(
         path,
         config,
       );
-      const mappedResponse = response.data.map((item) => {
-        return {
-          currency: item.currency,
-          createdAt: item.created_at,
-          updatedAt: item.updated_at,
-          uuid: item.uuid,
-        };
+      return response.data.map((bankAccount) => {
+        return this.mapUnblockBankAccountToCamelCase(bankAccount);
       });
-      return mappedResponse;
     } catch (error) {
       ErrorHandler.handle(error);
     }
   }
 
-  async simulateOnRamp(params: SimulateOnRampRequest): Promise<SimulateOnRampResponse> {
+  async simulateOnRamp(params: SimulateOnRampRequest): Promise<void> {
     const { apiKey } = this.props;
     try {
-      if (!this.props.userSessionData?.userUuid || !this.props.userSessionData.unblockSessionId) {
+      if (!this.props.userSessionData?.unblockSessionId) {
         throw new UserSessionDataNotSetError();
       }
 
-      const path = `/user/${this.props.userSessionData.userUuid}/bank-account/unblock/test`;
-      const body = { currency: params.currency, value: params.value };
+      const path = `/user/bank-account/unblock/${params.accountUuid}/simulate`;
+      const body = { account_uuid: params.accountUuid, value: params.value };
       const config = {
         headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
+          'Content-type': 'application/json',
           Authorization: apiKey,
           'unblock-session-id': this.props.userSessionData.unblockSessionId,
         },
       };
-      const response: AxiosResponse<{ message: string }> = await this.axiosClient.post(
-        path,
-        body,
-        config,
-      );
-      return response.data;
+      await this.axiosClient.post(path, body, config);
     } catch (error) {
       ErrorHandler.handle(error);
     }
   }
 
-  async getUnblockBankAccountById(
-    params: GetUnblockBankAccountByIdRequest,
-  ): Promise<GetUnblockBankAccountByIdResponse> {
+  async getUnblockBankAccountByUuid(
+    params: GetUnblockBankAccountByUuidRequest,
+  ): Promise<GetUnblockBankAccountByUuidResponse> {
     const { apiKey } = this.props;
     try {
-      if (!this.props.userSessionData?.userUuid || !this.props.userSessionData.unblockSessionId) {
+      if (!this.props.userSessionData?.unblockSessionId) {
         throw new UserSessionDataNotSetError();
       }
 
-      const path = `/user/${this.props.userSessionData.userUuid}/bank-account/unblock/${params.accountUuid}`;
+      const path = `/user/bank-account/unblock/${params.accountUuid}`;
       const config = {
         headers: {
           accept: 'application/json',
@@ -142,26 +123,27 @@ export class UserFiatToCryptoService extends BaseService implements IUserFiatToC
           'unblock-session-id': this.props.userSessionData.unblockSessionId,
         },
       };
-      const response: AxiosResponse<UnblockUserBankAccountFull> = await this.axiosClient.get(
+      const response: AxiosResponse<{ [key: string]: any }> = await this.axiosClient.get(
         path,
         config,
       );
 
-      return {
-        currency: response.data.currency,
-        createdAt: response.data.created_at,
-        updatedAt: response.data.updated_at,
-        uuid: response.data.uuid,
-        bic: response.data.bic,
-        accountNumber: response.data.account_number,
-        iban: response.data.iban,
-        holderName: response.data.holder_name,
-        currentBalance: response.data.current_balance,
-        availableBalance: response.data.available_balance,
-        sortCode: response.data.sort_code,
-      };
+      return this.mapUnblockBankAccountToCamelCase(response.data);
     } catch (error) {
       ErrorHandler.handle(error);
     }
+  }
+
+  private mapUnblockBankAccountToCamelCase(bankAccount: {
+    [key: string]: any;
+  }): UnblockBankAccount {
+    return {
+      uuid: bankAccount.uuid,
+      currency: bankAccount.currency,
+      iban: bankAccount.iban,
+      bic: bankAccount.bic,
+      accountNumber: bankAccount.account_number,
+      sortCode: bankAccount.sort_code,
+    };
   }
 }

--- a/src/user/fiat-to-crypto/definitions.ts
+++ b/src/user/fiat-to-crypto/definitions.ts
@@ -1,61 +1,28 @@
-export type UserBankAccount = {
-  currency: string; // ISO-4217 currency code
-  createdAt: string;
-  updatedAt: string;
-  uuid: string;
-};
+import { Currency } from '../../enums/Currency';
 
-export type UserBankAccountDetails = {
+export type UnblockBankAccount = {
+  uuid: string;
+  currency: Currency;
+  iban: string;
   bic: string;
   accountNumber: string;
-  iban: string;
-  holderName: string;
-  currentBalance: number;
-  availableBalance: number;
   sortCode: string;
 };
 
-export type UserBankAccountFull = UserBankAccount & UserBankAccountDetails;
+/** Request dto */
+export type CreateUnblockUserBankAccountRequest = { currency: Currency };
+
+/** Response dto */
+export type CreateUnblockUserBankAccountResponse = UnblockBankAccount;
+
+/** Response dto */
+export type GetAllunblockUserBankAccountsResponse = UnblockBankAccount[];
 
 /** Request dto */
-export type CreateUnblockUserBankAccountRequest = { currency: string };
+export type GetUnblockBankAccountByUuidRequest = { accountUuid: string };
+
+/** Response dto */
+export type GetUnblockBankAccountByUuidResponse = UnblockBankAccount;
 
 /** Request dto */
-export type SimulateOnRampRequest = { currency: string; value: number };
-
-/** Request dto */
-export type GetUnblockBankAccountByIdRequest = { accountUuid: string };
-
-/** Response dto */
-export type CreateUnblockUserBankAccountResponse = UserBankAccount;
-
-/** Response dto */
-export type GetAllunblockUserBankAccountsResponse = UserBankAccount[];
-
-/** Response dto */
-export type SimulateOnRampResponse = { message: string };
-
-/** Response dto */
-export type GetUnblockBankAccountByIdResponse = UserBankAccountFull;
-
-/** GetUnblock API response data */
-export type UnblockUserBankAccount = {
-  currency: string; // ISO-4217 currency code
-  created_at: string;
-  updated_at: string;
-  uuid: string;
-};
-
-/** GetUnblock API response data */
-export type UnblockUserBankAccountDetails = {
-  bic: string;
-  account_number: string;
-  iban: string;
-  holder_name: string;
-  current_balance: number;
-  available_balance: number;
-  sort_code: string;
-};
-
-/** GetUnblock API response data */
-export type UnblockUserBankAccountFull = UnblockUserBankAccount & UnblockUserBankAccountDetails;
+export type SimulateOnRampRequest = { accountUuid: string; value: number };

--- a/src/user/fiat-to-crypto/definitions.ts
+++ b/src/user/fiat-to-crypto/definitions.ts
@@ -25,4 +25,4 @@ export type GetUnblockBankAccountByUuidRequest = { accountUuid: string };
 export type GetUnblockBankAccountByUuidResponse = UnblockBankAccount;
 
 /** Request dto */
-export type SimulateOnRampRequest = { accountUuid: string; value: number };
+export type simulateRequest = { accountUuid: string; value: number };

--- a/tests/corporate/fiat-to-crypto/CorporateFiatToCryptoService.spec.ts
+++ b/tests/corporate/fiat-to-crypto/CorporateFiatToCryptoService.spec.ts
@@ -259,7 +259,7 @@ describe('CorporateFiatToCryptoService', () => {
     });
   });
 
-  describe('simulateFiatToCrypto', () => {
+  describe('simulate', () => {
     // Happy
     it('Should call axios with expected params', async () => {
       // Arrange
@@ -288,7 +288,7 @@ describe('CorporateFiatToCryptoService', () => {
       const service = new CorporateFiatToCryptoService(props);
 
       // Act
-      await service.simulateFiatToCrypto({ corporateUuid, accountUuid, value });
+      await service.simulate({ corporateUuid, accountUuid, value });
 
       // Assert
       expect(axiosClient.post).toBeCalledTimes(1);
@@ -307,7 +307,7 @@ describe('CorporateFiatToCryptoService', () => {
 
       // Act
       try {
-        await service.simulateFiatToCrypto({
+        await service.simulate({
           corporateUuid,
           accountUuid: faker.datatype.uuid(),
           value: 100,
@@ -339,7 +339,7 @@ describe('CorporateFiatToCryptoService', () => {
 
       // Act
       try {
-        await service.simulateFiatToCrypto({
+        await service.simulate({
           corporateUuid,
           accountUuid: faker.datatype.uuid(),
           value: 100,

--- a/tests/mocks/props.mock.ts
+++ b/tests/mocks/props.mock.ts
@@ -2,4 +2,4 @@ import { faker } from '@faker-js/faker';
 import { SdkSettings } from '../../src/SdkSettings';
 
 export const propsMock = (): SdkSettings =>
-  new SdkSettings(`API-Key ${faker.datatype.string(64)}`, faker.datatype.boolean());
+  new SdkSettings(`API-Key ${faker.datatype.string(64)}`, false);


### PR DESCRIPTION
-> Added implementation for user fiat to crypto service
-> Refactored unit tests accordingly. Added one more to test forbidden production calls on simulate
-> Added docs for user fiat to crypto service
-> Refactored method from corporate (simulateFiatToCrypto) to be called simply simulate since usage is better as `sdk.corporate.fiatToCrypto.simulate` than `sdk.corporate.fiatToCrypto.simulateFiatToCrypto`